### PR TITLE
Fix missing eKOTH definition

### DIFF
--- a/KOTH/Scripts/3_Game/KOTH_Defines.c
+++ b/KOTH/Scripts/3_Game/KOTH_Defines.c
@@ -1,0 +1,8 @@
+enum eKOTH
+{
+    LOG_CRITICAL = 1,
+    LOG_BASIC,
+    LOG_VERBOSE,
+
+    RPC_KOTH_CONFIG_SYNC = 1000
+};


### PR DESCRIPTION
## Summary
- add `eKOTH` enum used by logging and RPCs

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6848b2b05ac08326a7b08a9e8281a8e2