### PR TITLE
Fix preprocessor spacing in VPP.c

### DIFF
--- a/KOTH/Scripts/5_Mission/3rdParty/VPP.c
+++ b/KOTH/Scripts/5_Mission/3rdParty/VPP.c
@@ -1,4 +1,4 @@
-# ifdef VanillaPPMap
+#ifdef VanillaPPMap
 modded class MissionServer extends MissionBase {
     void AddKOTHMarkerVPP(MarkerInfo newMarker) {
         m_ServerMarkersCache.AddKOTHMarker(newMarker);
@@ -15,4 +15,4 @@ modded class MissionServer extends MissionBase {
         }
     }
 }
-# endif
+#endif


### PR DESCRIPTION
## Summary
- fix spacing for `#ifdef` and `#endif` in `VPP.c`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6848b70d54f48326872ca26f679bc3a3