### PR TITLE
Fix crash when workspace not ready

### DIFF
--- a/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
+++ b/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
@@ -12,10 +12,25 @@ class KOTH_CaptureProgressUI
 
     void KOTH_CaptureProgressUI()
     {
-        m_Root = GetGame().GetWorkspace().CreateWidgets("KOTH/GUI/layouts/koth_capture_bar.layout");
+        Workspace workspace = GetGame().GetWorkspace();
+        if (!workspace)
+        {
+            Print("[KOTH] Workspace not ready, capture UI will not be created.");
+            return;
+        }
+
+        m_Root = workspace.CreateWidgets("KOTH/GUI/layouts/koth_capture_bar.layout");
+
+        if (!m_Root)
+        {
+            Print("[KOTH] Failed to create capture progress UI, layout missing.");
+            return;
+        }
+
         m_Background = ImageWidget.Cast(m_Root.FindAnyWidget("Background"));
         m_Bar = ImageWidget.Cast(m_Root.FindAnyWidget("Bar"));
         m_Text = TextWidget.Cast(m_Root.FindAnyWidget("ProgressText"));
+
         m_Root.Show(false);
         m_IsVisible = false;
     }


### PR DESCRIPTION
## Summary
- avoid game crash when workspace isn't available

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6848bdb2701c8326b2109e5e03f3a847