### PR TITLE
Fix capture progress UI workspace type

### DIFF
--- a/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
+++ b/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
@@ -12,7 +12,7 @@ class KOTH_CaptureProgressUI
 
     void KOTH_CaptureProgressUI()
     {
-        UIWorkspace workspace = GetGame().GetWorkspace();
+        WorkspaceWidget workspace = GetGame().GetWorkspace();
         if (!workspace)
         {
             Print("[KOTH] Workspace not ready, capture UI will not be created.");


### PR DESCRIPTION
## Summary
- fix invalid type used when grabbing the workspace for the capture progress UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848bfea82308326b65190c24fd1d72f