### PR TITLE
Fix UI init crash

### DIFF
--- a/KOTH/Scripts/5_Mission/MissionGameplay.c
+++ b/KOTH/Scripts/5_Mission/MissionGameplay.c
@@ -5,17 +5,19 @@ modded class MissionGameplay extends MissionBase
     override void OnInit()
     {
         super.OnInit();
-        m_KOTHCaptureUI = new KOTH_CaptureProgressUI();
     }
 
-    #ifdef BASICMAP
     override void OnMissionStart()
     {
         super.OnMissionStart();
+        m_KOTHCaptureUI = new KOTH_CaptureProgressUI();
+#ifdef BASICMAP
         Print("Requesting group update for KOTH.");
         BasicMap().RequestGroupUpdate("KOTH");
+#endif
     }
-    #endif
+
+    
 
     override void OnUpdate(float timeslice)
     {


### PR DESCRIPTION
## Summary
- create CaptureProgressUI after mission start instead of during init

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848c24a78588326a5589224b9de9ea7