### PR TITLE
Fix CallLater argument mismatch

### DIFF
--- a/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
+++ b/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
@@ -15,7 +15,9 @@ class KOTH_CaptureProgressUI
     {
         // Schedule initialization on the GUI call queue. Using CallLater
         // ensures the Init method is invoked correctly for this instance.
-        GetGame().GetCallQueue(CALL_CATEGORY_GUI).CallLater(this, "Init", 0, false);
+        // Pass a bound method reference instead of object + string to avoid
+        // type-mismatch errors when scheduling with CallLater.
+        GetGame().GetCallQueue(CALL_CATEGORY_GUI).CallLater(this.Init, 0, false);
         m_IsVisible = false;
         m_Initialized = false;
     }


### PR DESCRIPTION
## Summary
- schedule `Init` using a bound method pointer in `KOTH_CaptureProgressUI`

## Testing
- `grep -n "CallLater" -R KOTH | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6848c69df6b08326bcad448df18dd1b7