### PR TITLE
Fix crash when initializing capture progress UI

### DIFF
--- a/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
+++ b/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
@@ -23,10 +23,15 @@ class KOTH_CaptureProgressUI
 
     void Init()
     {
+        if (m_Initialized)
+            return;
+
         WorkspaceWidget workspace = GetGame().GetWorkspace();
         if (!workspace)
         {
-            Print("[KOTH] Workspace not ready, capture UI will not be created.");
+            // Workspace might not be available yet during login. Try again
+            // shortly to avoid a crash when creating widgets too early.
+            GetGame().GetCallQueue(CALL_CATEGORY_GUI).CallLater(Init, 100, false, this);
             return;
         }
 


### PR DESCRIPTION
## Summary
- handle missing workspace in `KOTH_CaptureProgressUI.Init`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848cf9ec7fc832683099db69c0738e7