### PR TITLE
Fix UI crash on login

### DIFF
--- a/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
+++ b/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
@@ -15,8 +15,10 @@ class KOTH_CaptureProgressUI
     {
         // Schedule initialization on the GUI call queue. Providing the object
         // reference ensures the method executes on this instance even if the
-        // call is processed after construction.
-        GetGame().GetCallQueue(CALL_CATEGORY_GUI).CallLater(this.Init, 0, false);
+        // call is processed after construction. Delay slightly to make sure
+        // the game UI has been fully created before we attempt to spawn
+        // our widgets.
+        GetGame().GetCallQueue(CALL_CATEGORY_GUI).CallLater(this.Init, 1000, false);
         m_IsVisible = false;
         m_Initialized = false;
     }
@@ -39,7 +41,10 @@ class KOTH_CaptureProgressUI
 
         if (!m_Root)
         {
-            Print("[KOTH] Failed to create capture progress UI, layout missing.");
+            // If the widget failed to create, the UI may still be initializing.
+            // Retry shortly instead of letting the game crash on a null pointer.
+            Print("[KOTH] Failed to create capture progress UI, layout missing or workspace not ready. Retrying...");
+            GetGame().GetCallQueue(CALL_CATEGORY_GUI).CallLater(this.Init, 100, false);
             return;
         }
 


### PR DESCRIPTION
## Summary
- delay KOTH capture progress UI initialization
- add retry logic if workspace or layout isn't ready

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848d6d3d1208326a7694de8b6acc148