### PR TITLE
Fix workspace initialization in capture progress UI

### DIFF
--- a/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
+++ b/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
@@ -30,21 +30,7 @@ class KOTH_CaptureProgressUI
         if (m_Initialized)
             return;
 
-        DayZGame game = DayZGame.Cast(GetGame());
-        if (!game)
-        {
-            GetGame().GetCallQueue(CALL_CATEGORY_GUI).CallLater(this.Init, 100, false);
-            return;
-        }
-
-        UIManager uiManager = game.GetUIManager();
-        if (!uiManager)
-        {
-            GetGame().GetCallQueue(CALL_CATEGORY_GUI).CallLater(this.Init, 100, false);
-            return;
-        }
-
-        WorkspaceWidget workspace = uiManager.GetWorkspace();
+        WorkspaceWidget workspace = GetGame().GetWorkspace();
         if (!workspace)
         {
             // Workspace might not be available yet during login. Try again


### PR DESCRIPTION
## Summary
- access workspace directly from `GetGame()` instead of from `UIManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848df3df734832694fa2418158eb01f