### PR TITLE
Fix capture UI workspace initialization

### DIFF
--- a/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
+++ b/KOTH/Scripts/5_Mission/KOTH_CaptureProgressUI.c
@@ -30,7 +30,9 @@ class KOTH_CaptureProgressUI
         if (m_Initialized)
             return;
 
-        WorkspaceWidget workspace = game.GetWorkspace();
+        // Use the global GetGame() accessor to retrieve the workspace rather
+        // than referencing a non-existent "game" variable.
+        WorkspaceWidget workspace = GetGame().GetWorkspace();
         if (!workspace)
         {
             // Workspace might not be available yet during login. Try again


### PR DESCRIPTION
## Summary
- ensure workspace is retrieved using `GetGame()`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848e35059088326878357f7788cfb81