### PR TITLE
Add KOTH capture progress bar

### DIFF
--- a/KOTH/Scripts/5_Mission/KOTH_ProgressBar.c
+++ b/KOTH/Scripts/5_Mission/KOTH_ProgressBar.c
@@ -1,0 +1,36 @@
+class KOTH_ProgressBar {
+    protected Widget m_Root;
+    protected ProgressBarWidget m_Bar;
+    protected TextWidget m_Text;
+    protected bool m_Visible;
+
+    void KOTH_ProgressBar() {
+        if (!GetGame()) return;
+        m_Root = GetGame().GetWorkspace().CreateWidgets("KOTH/gui/layouts/koth_progress.layout");
+        m_Bar = ProgressBarWidget.Cast(m_Root.FindAnyWidget("ProgressBar"));
+        m_Text = TextWidget.Cast(m_Root.FindAnyWidget("ProgressText"));
+        Hide();
+    }
+
+    void Show() {
+        if (m_Root) m_Root.Show(true);
+        m_Visible = true;
+    }
+
+    void Hide() {
+        if (m_Root) m_Root.Show(false);
+        m_Visible = false;
+    }
+
+    bool IsVisible() {
+        return m_Visible;
+    }
+
+    void SetProgress(float percent) {
+        if (!m_Bar || !m_Text) return;
+        if (percent < 0) percent = 0;
+        if (percent > 100) percent = 100;
+        m_Bar.SetCurrent(percent);
+        m_Text.SetText(string.Format("%1%%", Math.Round(percent).ToString()));
+    }
+}

--- a/KOTH/Scripts/5_Mission/MissionGameplay.c
+++ b/KOTH/Scripts/5_Mission/MissionGameplay.c
@@ -1,13 +1,57 @@
-/*
-modded class MissionGameplay extends MissionBase
-{
-	#ifdef BASICMAP
-	override void OnMissionStart()
-	{
-		super.OnMissionStart();
-		Print("Requesting group update for KOTH.");
-		BasicMap().RequestGroupUpdate("KOTH");
-	}
-	#endif
+modded class MissionGameplay extends MissionBase {
+    protected ref KOTH_ProgressBar m_KOTHBar;
+    protected ref Timer m_KOTHTimer;
+
+    override void OnMissionStart() {
+        super.OnMissionStart();
+#ifdef BASICMAP
+        Print("Requesting group update for KOTH.");
+        BasicMap().RequestGroupUpdate("KOTH");
+#endif
+        m_KOTHBar = new KOTH_ProgressBar();
+        m_KOTHTimer = new Timer();
+        m_KOTHTimer.Run(1, this, "KOTH_UpdateProgress", NULL, true);
+    }
+
+    void KOTH_UpdateProgress() {
+        if (!KOTH_Settings.IsEnabled()) {
+            if (m_KOTHBar && m_KOTHBar.IsVisible()) m_KOTHBar.Hide();
+            return;
+        }
+
+        PlayerBase player = PlayerBase.Cast(GetGame().GetPlayer());
+        if (!player) {
+            if (m_KOTHBar && m_KOTHBar.IsVisible()) m_KOTHBar.Hide();
+            return;
+        }
+
+        KOTH_Flag nearestFlag;
+        KOTH_Zone zone;
+        float nearestDist = 0;
+        foreach(KOTH_Zone z : KOTH_Settings.GetZones()) {
+            vector zp = z.GetPosition();
+            if (vector.Distance(player.GetPosition(), zp) <= z.GetRadius()) {
+                array<Object> objs = new array<Object>;
+                array<CargoBase> prox = new array<CargoBase>;
+                GetGame().GetObjectsAtPosition(zp, 5, objs, prox);
+                foreach(Object obj : objs) {
+                    if (Class.CastTo(nearestFlag, obj)) {
+                        zone = z;
+                        break;
+                    }
+                }
+            }
+            if (nearestFlag) break;
+        }
+
+        if (nearestFlag && zone) {
+            float progress = (1.0 - nearestFlag.GetAnimationPhase("flag_mast")) * 100.0;
+            if (progress < 0) progress = 0;
+            if (progress > 100) progress = 100;
+            m_KOTHBar.SetProgress(progress);
+            if (!m_KOTHBar.IsVisible()) m_KOTHBar.Show();
+        } else {
+            if (m_KOTHBar.IsVisible()) m_KOTHBar.Hide();
+        }
+    }
 }
-*/

--- a/KOTH/gui/layouts/koth_progress.layout
+++ b/KOTH/gui/layouts/koth_progress.layout
@@ -1,0 +1,4 @@
+<Widget name="KOTHProgressRoot" type="PanelWidget" flags="0" size="0.3 0.05" align="left bottom" x="0.02" y="-0.25">
+    <ProgressBarWidget name="ProgressBar" align="left center" size="1 0.6" color="0 1 0 1" style="progressbar" />
+    <TextWidget name="ProgressText" text="0%" align="center" size="1 1" />
+</Widget>


### PR DESCRIPTION
## Summary
- add a simple layout and script to show capture progress
- update `MissionGameplay` to track nearest KOTH flag and display a progress bar

## Testing
- `No tests available`


------
https://chatgpt.com/codex/tasks/task_e_6848e9d2bf9c83268695ed8f8b961515