### PR TITLE
Fix timer usage in MissionGameplay

### DIFF
--- a/KOTH/Scripts/5_Mission/MissionGameplay.c
+++ b/KOTH/Scripts/5_Mission/MissionGameplay.c
@@ -1,6 +1,5 @@
 modded class MissionGameplay extends MissionBase {
     protected ref KOTH_ProgressBar m_KOTHBar;
-    protected ref Timer m_KOTHTimer;
 
     override void OnMissionStart() {
         super.OnMissionStart();
@@ -9,8 +8,7 @@ modded class MissionGameplay extends MissionBase {
         BasicMap().RequestGroupUpdate("KOTH");
 #endif
         m_KOTHBar = new KOTH_ProgressBar();
-        m_KOTHTimer = new Timer();
-        m_KOTHTimer.Run(1, this, "KOTH_UpdateProgress", NULL, true);
+        GetGame().GetCallQueue(CALL_CATEGORY_GUI).CallLater(KOTH_UpdateProgress, 1000, true, this);
     }
 
     void KOTH_UpdateProgress() {


### PR DESCRIPTION
## Summary
- replace Timer usage with CallQueue in MissionGameplay to avoid `Managed` compilation error

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848fbce2b1083269b0e5386f2dfc09f