### PR TITLE
Fix JsonLoadFile compile error

### DIFF
--- a/KOTH/Scripts/3_Game/KOTH_Loot.c
+++ b/KOTH/Scripts/3_Game/KOTH_Loot.c
@@ -17,11 +17,7 @@ class KOTH_Loot {
             m_Data.InitDefaults();
             SaveData();
         } else {
-            if (!JsonFileLoader<KOTH_LootData>.JsonLoadFile(m_Path, m_Data)) {
-                // fallback to defaults if json is corrupt
-                KOTH_Log.LogCritical("Failed to load loot config, using defaults.");
-                m_Data.InitDefaults();
-            }
+            JsonFileLoader<KOTH_LootData>.JsonLoadFile(m_Path, m_Data);
             SaveData(); // Update settings
         }
 

--- a/KOTH/Scripts/3_Game/KOTH_Settings.c
+++ b/KOTH/Scripts/3_Game/KOTH_Settings.c
@@ -18,10 +18,7 @@ class KOTH_Settings {
             m_Data.InitDefaults(m_WorldName);
             SaveData();
         } else {
-            if (!JsonFileLoader<KOTH_SettingsData>.JsonLoadFile(cfgPath, m_Data)) {
-                KOTH_Log.LogCritical("Failed to load KOTH config, using defaults.");
-                m_Data.InitDefaults(m_WorldName);
-            }
+            JsonFileLoader<KOTH_SettingsData>.JsonLoadFile(cfgPath, m_Data);
             UpgradeData();
             SaveData(); // Update settings
         }


### PR DESCRIPTION
## Summary
- fix compile error when calling JsonLoadFile in KOTH settings and loot

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848ff51394083268ce299cbe5b66226